### PR TITLE
update openapi schema w/ JSON request

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13,88 +13,114 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-swagger: "2.0"
+openapi: 3.0.1
 info:
   title: Timestamp Authority
   description: Timestamp Authority provides an RFC3161 timestamp authority.
   version: 0.0.1
-
-host: timestamp.sigstore.dev
-schemes:
-  - http
-
+servers:
+- url: http://timestamp.sigstore.dev/
 paths:
   /api/v1/timestamp:
     post:
-      summary: Generates a new timestamp response and creates a new log entry for the timestamp in the transparency log
-      operationId: getTimestampResponse
       tags:
-        - timestamp
-      consumes:
-        - application/timestamp-query
-        - application/json
-      produces:
-        - application/timestamp-reply
-      parameters:
-        - in: body
-          name: request
-          required: true
-          schema:
-            type: string
-            format: binary
+      - timestamp
+      summary: Generates a new timestamp response and creates a new log entry for
+        the timestamp in the transparency log
+      operationId: getTimestampResponse
+      requestBody:
+        content:
+          application/timestamp-query:
+            schema:
+              type: string
+              format: binary
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TimestampRequest'
+        required: true
       responses:
         201:
-          description: Returns a timestamp response and the location of the log entry in the transprency log
-          schema:
-            type: string
-            format: binary
+          description: Returns a timestamp response
+          content:
+            application/timestamp-reply:
+              schema:
+                type: string
+                format: binary
         400:
-          $ref: '#/responses/BadContent'
+          $ref: '#/components/responses/BadContent'
         501:
-          $ref: '#/responses/NotImplemented'
+          $ref: '#/components/responses/NotImplemented'
         default:
-          $ref: '#/responses/InternalServerError'
-
+          $ref: '#/components/responses/InternalServerError'
+      x-codegen-request-body-name: request
   /api/v1/timestamp/certchain:
     get:
-      summary: Retrieve the certficate chain for timestamping that can be used to validate trusted timestamps
-      description: Returns the certficate chain for timestamping that can be used to validate trusted timestamps
-      operationId: getTimestampCertChain
       tags:
-        - timestamp
-      consumes:
-        - application/json
-      produces:
-        - application/pem-certificate-chain
+      - timestamp
+      summary: Retrieve the certficate chain for timestamping that can be used to
+        validate trusted timestamps
+      description: Returns the certficate chain for timestamping that can be used
+        to validate trusted timestamps
+      operationId: getTimestampCertChain
       responses:
         200:
           description: The PEM encoded cert chain
-          schema:
-            type: string
+          content:
+            application/pem-certificate-chain:
+              schema:
+                type: string
         404:
-          $ref: '#/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
         default:
-          $ref: '#/responses/InternalServerError'
+          $ref: '#/components/responses/InternalServerError'
 
-definitions:
-  Error:
-    type: object
-    properties:
-      code:
-        type: integer
-      message:
-        type: string
-
-responses:
-  BadContent:
-    description: The content supplied to the server was invalid
-    schema:
-      $ref: "#/definitions/Error"
-  NotFound:
-    description: The content requested could not be found
-  NotImplemented:
-    description: The content requested is not implemented
-  InternalServerError:
-    description: There was an internal error in the server while processing the request
-    schema:
-      $ref: "#/definitions/Error"
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+    TimestampRequest:
+      type: object
+      properties:
+        artifactHash:
+          type: string
+          format: binary
+          description: "digest of the artifact to be timestamped (base64 encoded)"
+          example: "MDM2NzVhYzUzZ"
+        hashAlgorithm:
+          type: string
+          enum: ["sha256", "sha384", "sha512"]
+          example: sha256
+        certificiates:
+          type: boolean
+          description: "whether or not to include the certificate chain in the timestamp response"
+        nonce:
+          type: number
+        tsaPolicyOID:
+          type: string
+          description: "dotted OID notation for the policy that the TSA should use"
+          example: 1.2.3.4
+  responses:
+    BadContent:
+      description: The content supplied to the server was invalid
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalServerError:
+      description: There was an internal error in the server while processing the
+        request
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/Error'
+    NotFound:
+      description: The content requested could not be found
+      content: {}
+    NotImplemented:
+      description: The content requested is not implemented
+      content: {}


### PR DESCRIPTION
I thought it might be nice to update the openapi schema to fully document the JSON-style timestamp API . . . however, I realized that you have to upgrade from swagger 2 to openapi 3 in order to get support for describing different request bodies per mimetype.

Not sure what the other implications may be for upgrading these schema so you can decide whether you want to merge this or not.